### PR TITLE
Fix floor bug

### DIFF
--- a/snag.py
+++ b/snag.py
@@ -33,7 +33,7 @@ class SnagTask:
     co2_actual: int = 0
     co2_worst: int = 0
     duration_scheduled: int = 10
-    duration_actual: int = 0
+    duration_actual: float = 0
     has_run: bool = False
     base_host: str = "https://api.carbonintensity.org.uk"
     tolerance: int = 5

--- a/snag.py
+++ b/snag.py
@@ -12,7 +12,7 @@ import os
 import configparser
 from pathlib import Path
 import math
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 import sys
 
 
@@ -48,7 +48,7 @@ class SnagTask:
         self.due_by = due_by_dt.strftime("%Y-%m-%dT%H:%M")
 
 
-def query_api(url: str, verbose: bool = False) -> json:
+def query_api(url: str, verbose: bool = False) -> Dict:
     """
     Send a query to National Grid API and return the JSON representation
     :param url: full string to fetch from
@@ -83,7 +83,7 @@ def query_api(url: str, verbose: bool = False) -> json:
     try:
         data = page.read()
         encoding = page.info().get_content_charset("utf-8")
-        return_json: json = json.loads(data.decode(encoding))
+        return_json: Dict = json.loads(data.decode(encoding))
     except Exception as e:
         print(f"Unhandled error parsing JSON: {e}")
         exit(1)
@@ -91,7 +91,7 @@ def query_api(url: str, verbose: bool = False) -> json:
     return return_json
 
 
-def decompose_fw48(data: json,
+def decompose_fw48(data: Dict,
                    forecast_type: ForecastSource) -> List[Tuple[str, int]]:
     """
     Decompose a 48 hour forecast into a list of (ISO8601, intensity) pairs.
@@ -242,7 +242,7 @@ def schedule_task(task: SnagTask, verbose: bool = False) -> None:
         forecast_type = ForecastSource.POSTCODE
 
     # Fetch from the NG API, decompose into list of (time, intensity) points
-    ng_data: json = query_api(get_dest, verbose)
+    ng_data: Dict = query_api(get_dest, verbose)
     timepoints: List[Tuple[str, int]] = decompose_fw48(ng_data, forecast_type)
 
     # If the task will cross a 30 minute boundary, then calculate the weighted

--- a/snag.py
+++ b/snag.py
@@ -134,7 +134,7 @@ def half_hour_floor(dt: datetime.datetime) -> datetime.datetime:
         dt = (dt - datetime.timedelta(minutes=minute_mod30,
                                       seconds=dt.second,
                                       microseconds=dt.microsecond))
-        return dt
+    return dt
 
 
 def half_hour_ceil(dt: datetime.datetime) -> datetime.datetime:

--- a/test_snag.py
+++ b/test_snag.py
@@ -1,0 +1,42 @@
+import snag
+
+import datetime
+import unittest
+
+
+class TestDateTimeFunctions(unittest.TestCase):
+    def test_half_hour_floor(self):
+        test_cases = (
+            (datetime.datetime(2023, 4, 25, 11, 0, 0), datetime.datetime(2023, 4, 25, 11, 0, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 1, 0), datetime.datetime(2023, 4, 25, 11, 0, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 15, 0), datetime.datetime(2023, 4, 25, 11, 0, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 16, 0), datetime.datetime(2023, 4, 25, 11, 0, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 30, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 31, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 45, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 46, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+        )
+        for dt, expected in test_cases:
+            with self.subTest(dt=dt):
+                result = snag.half_hour_floor(dt)
+                self.assertEqual(result, expected)
+
+    def test_half_hour_ceil(self):
+        test_cases = (
+            (datetime.datetime(2023, 4, 25, 11, 0, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 1, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 15, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 16, 0), datetime.datetime(2023, 4, 25, 11, 30, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 30, 0), datetime.datetime(2023, 4, 25, 12, 0, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 31, 0), datetime.datetime(2023, 4, 25, 12, 0, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 45, 0), datetime.datetime(2023, 4, 25, 12, 0, 0)),
+            (datetime.datetime(2023, 4, 25, 11, 46, 0), datetime.datetime(2023, 4, 25, 12, 0, 0)),
+        )
+        for dt, expected in test_cases:
+            with self.subTest(dt=dt):
+                result = snag.half_hour_ceil(dt)
+                self.assertEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixing two typing issues and a bug in the half_hour_floor function.

* `json` is a module not a type, `json.loads` can return a whole host of native python types that can be represented in JSON, but I think it probably makes sense to use `Dict` rather than `Any`.
* `duration_actual` was typed as int, the values it works with are all floats, so just changing this to match.
* There was an indentation error in `half_hour_floor` that meant it returned `None` when the value of `dt` had a value of zero for the seconds and microseconds, I've added some test cases to cover it and `half_hour_ceil`.