### PR TITLE
Tidy imports

### DIFF
--- a/sizzler.py
+++ b/sizzler.py
@@ -8,11 +8,11 @@ lazily updated when required and pruned when unused for a period of time.
 """
 
 import datetime
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from urllib import request
-from time import sleep
-import urllib.error
 import sys
+import urllib.error
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from time import sleep
+from urllib import request
 
 
 class Sizzler(BaseHTTPRequestHandler):

--- a/snag.py
+++ b/snag.py
@@ -1,19 +1,19 @@
 import argparse
-import datetime
-import time
-from dataclasses import dataclass
-import json
-from enum import Enum
-import urllib.error
-from urllib import request
-import subprocess
-import shlex
-import os
 import configparser
-from pathlib import Path
+import datetime
+import json
 import math
-from typing import Tuple, List, Dict
+import os
+import shlex
+import subprocess
 import sys
+import time
+import urllib.error
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Tuple
+from urllib import request
 
 
 class ForecastSource(Enum):


### PR DESCRIPTION
Another small pull request that does 3 things.

* I ran `isort` on snag.py and sizzler.py just to order the imports and tidy it a bit.
* I removed an unused definition of `time_now`
* I changed `import datetime` to `from datetime import datetime, timedelta` as it shortens a few lines and hopefully helps readability.